### PR TITLE
Keys can now create subkeys that can only perform GET requests (as if…

### DIFF
--- a/emissary/emissary.log
+++ b/emissary/emissary.log
@@ -1,0 +1,1 @@
+15/08/2015 12:00:05 - Emissary - INFO - Starting Emissary 2.0.0.

--- a/emissary/resources/articles.py
+++ b/emissary/resources/articles.py
@@ -47,7 +47,7 @@ class ArticleCollection(restful.Resource):
 #		key = auth()
 
 #		parser = restful.reqparse.RequestParser()
-#		parser.add_argument("feed",type=str, help="", required=True)
+#		parser.add_argument("feed",type=str, help="", required=False)
 #		parser.add_argument("url",type=str, help="", required=True)
 #		args = parser.parse_args()
 #		return {}, 201
@@ -127,7 +127,7 @@ class ArticleResource(restful.Resource):
 		"""
 		 Delete an article.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		article = Article.query.filter(and_(Article.key == key, Article.uid == uid)).first()
 		if article:

--- a/emissary/resources/feedgroups.py
+++ b/emissary/resources/feedgroups.py
@@ -35,7 +35,7 @@ class FeedGroupCollection(restful.Resource):
 		"""
 		 Create a new feed group, providing the name isn't already in use.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		parser = restful.reqparse.RequestParser()
 		parser.add_argument("name",  type=str, help="", required=True)
@@ -74,7 +74,7 @@ class FeedGroupResource(restful.Resource):
 		 Create a new feed providing the name and url are unique.
 		 Feeds must be associated with a group.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		parser = restful.reqparse.RequestParser()
 		parser.add_argument("name",type=str, help="", required=True)
@@ -125,7 +125,7 @@ class FeedGroupResource(restful.Resource):
 	def post(self, groupname):
 		"Rename a feedgroup or toggle active status"
 
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		parser = restful.reqparse.RequestParser()
 		parser.add_argument("name",type=str, help="Rename a feed group",)
@@ -154,7 +154,7 @@ class FeedGroupResource(restful.Resource):
 
 	@gzipped
 	def delete(self, groupname):
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 		
 		fg = FeedGroup.query.filter(and_(FeedGroup.key == key, FeedGroup.name == groupname)).first()
 		if not fg:
@@ -222,7 +222,7 @@ class FeedGroupStart(restful.Resource):
 		"""
 		 Start all feeds within a group.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		fg = FeedGroup.query.filter(and_(FeedGroup.key == key, FeedGroup.name == groupname)).first()
 		if not fg:
@@ -235,7 +235,7 @@ class FeedGroupStart(restful.Resource):
 class FeedGroupStop(restful.Resource):
 
 	def post(self, groupname):
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		fg = FeedGroup.query.filter(and_(FeedGroup.key == key, FeedGroup.name == groupname)).first()
 		if not fg:

--- a/emissary/resources/feeds.py
+++ b/emissary/resources/feeds.py
@@ -25,7 +25,7 @@ class FeedCollection(restful.Resource):
 		 Create a new feed providing the name and url are unique.
 		 Feeds must be associated with a group.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		parser = restful.reqparse.RequestParser()
 		parser.add_argument("name",type=str, help="", required=True)
@@ -88,7 +88,7 @@ class FeedResource(restful.Resource):
 		"""
 		 Modify an existing feed.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		parser = restful.reqparse.RequestParser()
 		parser.add_argument("name",type=str, help="")
@@ -138,7 +138,7 @@ class FeedResource(restful.Resource):
 		 Halt and delete a feed.
 		 Default to deleting its articles.
 		"""
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 		feed = Feed.query.filter(and_(Feed.key == key, Feed.name == name)).first()
 		if not feed:
 			restful.abort(404)
@@ -219,7 +219,7 @@ class FeedSearch(restful.Resource):
 class FeedStartResource(restful.Resource):
 
 	def post(self, groupname, name):
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		feed = Feed.query.filter(and_(Feed.name == name, Feed.key == key)).first()
 		if feed:
@@ -230,7 +230,7 @@ class FeedStartResource(restful.Resource):
 class FeedStopResource(restful.Resource):
 
 	def post(self, groupname, name):
-		key = auth()
+		key = auth(forbid_reader_keys=True)
 
 		feed = Feed.query.filter(and_(Feed.name == name, Feed.key == key)).first()
 		if feed:


### PR DESCRIPTION
… they were their parent)

Created a self-referential join on api keys and a boolean reader field
modified the resources.api_key.auth function to optionally forbid reader keys
modified all resources to forbid reader keys from PUT, POST and DELETE
Reader keys cannot retrieve /v1/keys/:name (as it promotes them to their parent key)
