### PR TITLE
Fixed exception from calling "exit" command

### DIFF
--- a/emissary/repl.py
+++ b/emissary/repl.py
@@ -111,8 +111,12 @@ class repl(cmd.Cmd):
             self.display(response)
 
     def do_exit(self,line):
-        _curses.endwin()
-        raise SystemExit
+        try:
+            _curses.endwin()
+        except _curses.error:
+            pass
+        finally:
+            raise SystemExit
 
     def do_read(self,line):
         """


### PR DESCRIPTION
When calling `exit` without `--ncurses` option set raises a `_curses.error`:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Emissary-master/emissary/repl.py", line 295, in <module>
    r.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/Emissary-master/emissary/repl.py", line 114, in do_exit
    _curses.endwin()
_curses.error: must call initscr() first
```
